### PR TITLE
Add `power_limit` number entity to write NASA register 0x42F1 (50–150%)

### DIFF
--- a/components/samsung_ac/__init__.py
+++ b/components/samsung_ac/__init__.py
@@ -49,6 +49,7 @@ CONF_DEVICE_ADDRESS = "address"
 CONF_DEVICE_ROOM_TEMPERATURE = "room_temperature"
 CONF_DEVICE_ROOM_TEMPERATURE_OFFSET = "room_temperature_offset"
 CONF_DEVICE_TARGET_TEMPERATURE = "target_temperature"
+CONF_DEVICE_POWER_LIMIT = "power_limit"
 CONF_DEVICE_OUTDOOR_TEMPERATURE = "outdoor_temperature"
 CONF_DEVICE_POWER = "power"
 CONF_DEVICE_MODE = "mode"
@@ -235,6 +236,7 @@ DEVICE_SCHEMA = (
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_DEVICE_TARGET_TEMPERATURE): NUMBER_SCHEMA,
+            cv.Optional(CONF_DEVICE_POWER_LIMIT): NUMBER_SCHEMA,
             cv.Optional(CONF_DEVICE_POWER): switch.switch_schema(Samsung_AC_Switch),
             cv.Optional(CONF_DEVICE_MODE): SELECT_MODE_SCHEMA,
             cv.Optional(CONF_DEVICE_CLIMATE): CLIMATE_SCHEMA,
@@ -394,6 +396,16 @@ async def to_code(config):
                                           max_value=30.0,
                                           step=1.0)
             cg.add(var_dev.set_target_temperature_number(num))
+
+        if CONF_DEVICE_POWER_LIMIT in device:
+            conf = device[CONF_DEVICE_POWER_LIMIT]
+            conf[CONF_UNIT_OF_MEASUREMENT] = UNIT_PERCENT
+            conf[CONF_ICON] = "mdi:percent"
+            num = await number.new_number(conf,
+                                          min_value=50.0,
+                                          max_value=150.0,
+                                          step=1.0)
+            cg.add(var_dev.set_power_limit_number(num))
 
         if CONF_DEVICE_MODE in device:
             conf = device[CONF_DEVICE_MODE]

--- a/components/samsung_ac/protocol.h
+++ b/components/samsung_ac/protocol.h
@@ -90,6 +90,8 @@ namespace esphome
             optional<FanMode> fan_mode;
             optional<SwingMode> swing_mode;
             optional<AltMode> alt_mode;
+            optional<uint16_t> custom_message_number;
+            optional<long> custom_message_value;
             optional<Samsung_AC_CustClim *> caller; // used to analyze custom addresses
         };
 

--- a/components/samsung_ac/protocol_nasa.cpp
+++ b/components/samsung_ac/protocol_nasa.cpp
@@ -415,6 +415,14 @@ namespace esphome
                 packet.messages.push_back(targettemp);
             }
 
+            if (request.custom_message_number && request.custom_message_value)
+            {
+                MessageSet custom_message((MessageNumber)request.custom_message_number.value());
+                custom_message.value = request.custom_message_value.value();
+                packet.messages.push_back(custom_message);
+                ESP_LOGI(TAG, "Pushing custom value %ld at 0x%X for %s", custom_message.value, request.custom_message_number.value(), address.c_str());
+            }
+
             if (request.fan_mode)
             {
                 MessageSet fanmode(MessageNumber::ENUM_in_fan_mode);

--- a/example.yaml
+++ b/example.yaml
@@ -97,6 +97,8 @@ samsung_ac:
         name: "Kitchen temperature"
       target_temperature:
         name: "Kitchen target temperature"
+      power_limit:
+        name: "Kitchen power limit"
       power:
         name: "Kitchen power"
       mode:


### PR DESCRIPTION
### Motivation
- Provide a Home Assistant number input to limit the heatpump power by writing the NASA register `0x42F1` with the appropriate raw value. 
- Map a user-friendly percentage range (50–150%) to the NASA raw format so automations and the UI can set the maximum power limit.

### Description
- Added `CONF_DEVICE_POWER_LIMIT` and accepted `power_limit` in the device schema so a per-device `number` entity can be declared in YAML and created in `to_code` as a number with `min=50`, `max=150`, `step=1` and percent unit (`components/samsung_ac/__init__.py`).
- Implemented `set_power_limit_number(...)` on the device which converts the percentage to the NASA raw register value using `roundf(value * 6.12f)` and emits a `ProtocolRequest` carrying `custom_message_number = 0x42F1` and `custom_message_value = <raw>`; the number entity publishes its state after writing (`components/samsung_ac/samsung_ac_device.h`).
- Extended `ProtocolRequest` with `custom_message_number` and `custom_message_value` and updated the NASA protocol writer to append those custom `MessageSet` entries to outgoing packets when present (`components/samsung_ac/protocol.h`, `components/samsung_ac/protocol_nasa.cpp`).
- Added a short example entry for `power_limit` to `example.yaml`.

### Testing
- `python -m py_compile components/samsung_ac/__init__.py` completed successfully. 
- `./test/test_nasa.sh` was executed but failed in the repository test baseline due to unrelated build issues (missing `<cstdint>` includes in existing headers), not caused by the new `power_limit` changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df8ae8518832bab0e4cb3ef7b2454)