### PR TITLE
fix compiler warning

### DIFF
--- a/components/samsung_ac/samsung_ac_device.cpp
+++ b/components/samsung_ac/samsung_ac_device.cpp
@@ -15,7 +15,7 @@ namespace esphome
     {
       climate::ClimateTraits traits;
 
-      traits.set_supports_current_temperature(true);
+      traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
       traits.set_visual_temperature_step(1.0f);
       traits.set_visual_min_temperature(16.0f);
       traits.set_visual_max_temperature(30.0f);

--- a/components/samsung_ac/samsung_ac_device_custClim.cpp
+++ b/components/samsung_ac/samsung_ac_device_custClim.cpp
@@ -14,7 +14,7 @@ namespace esphome
     climate::ClimateTraits Samsung_AC_CustClim::traits() {
     auto traits = climate::ClimateTraits();
   
-    traits.set_supports_current_temperature(true);
+    traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
     traits.set_visual_temperature_step(1);
     traits.set_visual_min_temperature(setMin);
     traits.set_visual_max_temperature(setMax);


### PR DESCRIPTION
Fix this:

Compiling .pioenvs/esp-wp/src/esphome/components/samsung_ac/samsung_ac_device.cpp.o
src/esphome/components/samsung_ac/samsung_ac_device.cpp: In member function 'virtual esphome::climate::ClimateTraits esphome::samsung_ac::Samsung_AC_Climate::traits()':
src/esphome/components/samsung_ac/samsung_ac_device.cpp:18:46: warning: 'void esphome::climate::ClimateTraits::set_supports_current_temperature(bool)' is deprecated: This method is deprecated, use add_feature_flags() instead [-Wdeprecated-declarations]
   18 |       traits.set_supports_current_temperature(true);
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
In file included from src/esphome/components/climate/climate.h:10,
                 from src/esphome/components/samsung_ac/samsung_ac_device.h:11,
                 from src/esphome/components/samsung_ac/samsung_ac.h:9,
                 from src/esphome/components/samsung_ac/samsung_ac_device.cpp:2:
src/esphome/components/climate/climate_traits.h:89:8: note: declared here
   89 |   void set_supports_current_temperature(bool supports_current_temperature) {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Compiling .pioenvs/esp-wp/src/esphome/components/samsung_ac/samsung_ac_device_custClim.cpp.o
Compiling .pioenvs/esp-wp/src/esphome/components/samsung_ac/util.cpp.o
Compiling .pioenvs/esp-wp/src/esphome/components/select/select.cpp.o
Compiling .pioenvs/esp-wp/src/esphome/components/select/select_call.cpp.o
Compiling .pioenvs/esp-wp/src/esphome/components/select/select_traits.cpp.o
src/esphome/components/samsung_ac/samsung_ac_device_custClim.cpp: In member function 'virtual esphome::climate::ClimateTraits esphome::samsung_ac::Samsung_AC_CustClim::traits()':
src/esphome/components/samsung_ac/samsung_ac_device_custClim.cpp:17:44: warning: 'void esphome::climate::ClimateTraits::set_supports_current_temperature(bool)' is deprecated: This method is deprecated, use add_feature_flags() instead [-Wdeprecated-declarations]
   17 |     traits.set_supports_current_temperature(true);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
In file included from src/esphome/components/climate/climate.h:10,
                 from src/esphome/components/samsung_ac/samsung_ac_device_custClim.h:3,
                 from src/esphome/components/samsung_ac/samsung_ac_device_custClim.cpp:1:
src/esphome/components/climate/climate_traits.h:89:8: note: declared here
   89 |   void set_supports_current_temperature(bool supports_current_temperature) {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~